### PR TITLE
#42 Generate todos.json In The Running Folder.

### DIFF
--- a/src/main/java/com/selfxdsd/todocli/JsonTodosSerializer.java
+++ b/src/main/java/com/selfxdsd/todocli/JsonTodosSerializer.java
@@ -87,12 +87,7 @@ public final class JsonTodosSerializer implements TodosSerializer {
     private File getFile(final boolean deleteFirst) throws URISyntaxException,
             IOException {
         //folder where application is running.
-        final String parent = new File(JsonTodosSerializer.class
-                .getProtectionDomain()
-                .getCodeSource()
-                .getLocation()
-                .toURI())
-                .getParent();
+        final File parent = new File(System.getProperty("user.dir"));
         final File file = new File(parent, "todos.json");
         if (deleteFirst && file.exists()) {
             if (!file.delete()) {


### PR DESCRIPTION
fixes #42

tested on win:
in `sef-web` folder ran `java -jar %TODO-CLI%\todo-finder-cli-0.0.5-SNAPSHOT.jar` where sys env ` TODO-CLI` points the location of `todo-finder-cli` jar.

let me know if there are problems on linux.

--
no bounty, was a short fix.