### PR TITLE
Fixed some todo parsing corner cases.

### DIFF
--- a/src/main/java/com/selfxdsd/todocli/TodoParser.java
+++ b/src/main/java/com/selfxdsd/todocli/TodoParser.java
@@ -213,7 +213,7 @@ public final class TodoParser {
     private boolean isLinePartOfTodo(final int todoPosition, final String line){
         return todoPosition < line.length()
             && Character.isSpaceChar(line.charAt(todoPosition))
-            && line.substring(0, todoPosition)
+            && line.substring(0, todoPosition + 1)
              .matches("^"+GIT_BLAME_PATTERN+"\\s*\\W?\\s+$");
     }
 

--- a/src/main/java/com/selfxdsd/todocli/TodoParser.java
+++ b/src/main/java/com/selfxdsd/todocli/TodoParser.java
@@ -59,6 +59,7 @@ public final class TodoParser {
      * @param path Path to the file being parsed.
      * @return List of found TODOs.
      * @throws IOException If something goes wrong.
+     * @checkstyle ExecutableStatementCount (60 lines)
      */
     public List<Todo> parse(final String path) throws IOException {
         final List<Todo> todos = new ArrayList<>();
@@ -74,35 +75,55 @@ public final class TodoParser {
                 // for alignment in the case of multiline body todos.
                 // NOTE: this assumes that user is using 4 spaces for a tab.
                 line = line.replace("\t", " ".repeat(4));
-                if (todoPosition == -1) {
-                    todoPosition = this.checkForTodo(
-                        bodyBuilder,
-                        todoBuilder,
-                        lineIndex,
-                        line
-                    );
-                } else if (todoPosition < line.length()
-                    && Character.isSpaceChar(line.charAt(todoPosition))) {
-                    // if the character aligned to todoPosition is a white
-                    // space, then we have multiline.
-                    bodyBuilder.append(line.substring(todoPosition));
-                } else {
-                    final Todo todo = this.createTodo(
-                        bodyBuilder,
-                        todoBuilder,
-                        lineIndex
-                    );
-                    if (todo != null) {
-                        todos.add(todo);
+                if (!hasTodoStarted(todoPosition)) {
+                    final Matcher matcher = this.canStartTodo(line);
+                    if (matcher != null) {
+                        todoPosition = this.startTodo(
+                            matcher,
+                            bodyBuilder,
+                            todoBuilder,
+                            lineIndex,
+                            line
+                        );
                     }
-                    //reset buffer
-                    bodyBuilder.setLength(0);
-                    todoPosition = this.checkForTodo(
+                } else if (this.isLinePartOfTodo(todoPosition, line)) {
+                    // this line might start a todo too even if is passing the
+                    // todo line criteria.
+                    final Matcher matcher = this.canStartTodo(line);
+                    if (matcher != null) {
+                        this.endTodo(
+                            bodyBuilder,
+                            todoBuilder,
+                            lineIndex,
+                            todos
+                        );
+                        todoPosition = this.startTodo(
+                            matcher,
+                            bodyBuilder,
+                            todoBuilder,
+                            lineIndex,
+                            line
+                        );
+                    } else {
+                        this.addLineToTodo(todoPosition, line, bodyBuilder);
+                    }
+                } else {
+                    todoPosition = this.endTodo(
                         bodyBuilder,
                         todoBuilder,
                         lineIndex,
-                        line
+                        todos
                     );
+                    final Matcher matcher = this.canStartTodo(line);
+                    if (matcher != null) {
+                        todoPosition = this.startTodo(
+                            matcher,
+                            bodyBuilder,
+                            todoBuilder,
+                            lineIndex,
+                            line
+                        );
+                    }
                 }
             }
         }
@@ -110,51 +131,102 @@ public final class TodoParser {
     }
 
     /**
-     * Initializes a new todo and its body via builders when todo pattern
-     * is matching current line and returns the todo starting position.
-     * @param bodyBuilder Todo builder.
-     * @param todoBuilder Body builder.
-     * @param lineIndex Current line index.
-     * @param line Current line.
-     * @return Todo starting position in the line or -1 if there is no match.
+     * Checks if todo has started.
+     * @param todoPosition Position.
+     * @return Boolean
      */
-    private int checkForTodo(final StringBuilder bodyBuilder,
-                             final TodoBuilder todoBuilder,
-                             final int lineIndex,
-                             final String line) {
+    private boolean hasTodoStarted(final int todoPosition) {
+        return todoPosition != -1;
+    }
+
+    /**
+     * Checks if the line has valid todo in it.
+     * @param line Line.
+     * @return Matcher or null if there is no todo.
+     */
+    private Matcher canStartTodo(final String line){
         final Matcher matcher = TODO_PATTERN.matcher(line);
-        final int todoPosition;
+        final Matcher canStart;
         if (matcher.find()) {
-            todoPosition = matcher.start(3);
-            todoBuilder.setAuthor(matcher.group(1).trim())
-                .setTimestamp(matcher.group(2))
-                .setStart(lineIndex + 1);
-            bodyBuilder.append(matcher.group(6));
-            this.addHeader(todoBuilder, matcher.group(4));
+            canStart = matcher;
         } else {
-            todoPosition = -1;
+            canStart = null;
         }
+        return canStart;
+    }
+
+    /**
+     * Starts a todo.
+     * @param matcher Matcher
+     * @param bodyBuilder Todo body builder
+     * @param todoBuilder Tod builder.
+     * @param lineIndex File line index.
+     * @param line File line
+     * @return Starting position.
+     */
+    private int startTodo(final Matcher matcher,
+                          final StringBuilder bodyBuilder,
+                          final TodoBuilder todoBuilder,
+                          final int lineIndex,
+                          final String line){
+        final int todoPosition = matcher.start(3);
+        todoBuilder.setAuthor(matcher.group(1).trim())
+            .setTimestamp(matcher.group(2))
+            .setStart(lineIndex + 1);
+        bodyBuilder.append(matcher.group(6));
+        this.addHeader(todoBuilder, matcher.group(4));
         return todoPosition;
     }
 
     /**
-     * Creates the Todo if passes the body conditions.
-     * @param bodyBuilder Body builder.
+     * Ends the todo. This will create the Todo from builder and
+     * add it to the list. Also resets the body builder and reset
+     * the todoPosition (-1).
+     * @param bodyBuilder Todo body builder.
      * @param todoBuilder Todo builder.
-     * @param lineIndex Line index where will be the todo "end".
-     * @return Todo or null if was not created.
+     * @param lineIndex File line index.
+     * @param todos List of todos.
+     * @return Todo position reset value.
      */
-    private Todo createTodo(final StringBuilder bodyBuilder,
-                            final TodoBuilder todoBuilder,
-                            final int lineIndex) {
+    private int endTodo(final StringBuilder bodyBuilder,
+                        final TodoBuilder todoBuilder,
+                        final int lineIndex,
+                        final List<Todo> todos){
         final String body = bodyBuilder.toString().trim();
-        final Todo todo;
         if (!body.isBlank() && !body.startsWith("Autogenerated")) {
-            todo = todoBuilder.setBody(body).setEnd(lineIndex).build();
-        } else {
-            todo = null;
+            final Todo todo = todoBuilder
+                .setBody(body)
+                .setEnd(lineIndex)
+                .build();
+            todos.add(todo);
         }
-        return todo;
+        bodyBuilder.setLength(0);
+        return -1;
+    }
+
+    /**
+     * Checks if current line could be part of todo.
+     * @param todoPosition Todo position.
+     * @param line File line.
+     * @return Boolean.
+     */
+    private boolean isLinePartOfTodo(final int todoPosition, final String line){
+        return todoPosition < line.length()
+            && Character.isSpaceChar(line.charAt(todoPosition))
+            && line.substring(0, todoPosition)
+             .matches("^"+GIT_BLAME_PATTERN+"\\s*\\W?\\s+$");
+    }
+
+    /**
+     * Add current line to todo body builder starting from todoPosition.
+     * @param todoPosition Todo position.
+     * @param bodyBuilder Todo body builder.
+     * @param line File line.
+     */
+    private void addLineToTodo(final int todoPosition,
+                               final String line,
+                               final StringBuilder bodyBuilder){
+        bodyBuilder.append(line.substring(todoPosition).stripTrailing());
     }
 
     /**

--- a/src/test/java/com/selfxdsd/todocli/JsonTodosSerializerTestCase.java
+++ b/src/test/java/com/selfxdsd/todocli/JsonTodosSerializerTestCase.java
@@ -57,25 +57,20 @@ public final class JsonTodosSerializerTestCase {
         final URI location = serializer.serialize();
         final JsonReader reader = Json
             .createReader(location.toURL().openStream());
-        final JsonArray json = Json.createPatchBuilder()
-            .replace("/1/id", -2091730235)
-            .replace("/1/author", "cristianpela")
-            .replace("/1/timestamp", "2021-01-18 11:32:28 +0200")
-            .build()
-            .apply(reader.readArray());
+        final JsonArray json = reader.readArray();
         reader.close();
 
         MatcherAssert.assertThat(json, Matchers.equalTo(
             Json.createArrayBuilder()
                 .add(Json.createObjectBuilder()
-                    .add("id", 1194770182)
-                    .add("author", "Luka")
-                    .add("timestamp", "2020-11-08 09:32:57 +0100")
+                    .add("id", 888060502)
+                    .add("author", "cristianpela")
+                    .add("timestamp", "2021-01-18 12:29:17 +0200")
                     .add("start", 42)
                     .add("end", 42)
                     .add("originatingTicket", "#153")
                     .add("estimatedTime", 30)
-                    .add("body", "Add integration tests for filters.")
+                    .add("body", "Edit:Add integration tests for filters.")
                     .add("file", "src/test/resources/RtImagesITCase.java")
                     .build())
                 .add(Json.createObjectBuilder()

--- a/src/test/java/com/selfxdsd/todocli/JsonTodosSerializerTestCase.java
+++ b/src/test/java/com/selfxdsd/todocli/JsonTodosSerializerTestCase.java
@@ -74,18 +74,18 @@ public final class JsonTodosSerializerTestCase {
                     .add("file", "src/test/resources/RtImagesITCase.java")
                     .build())
                 .add(Json.createObjectBuilder()
-                    .add("id", -1377131499)
-                    .add("author", "Luka")
-                    .add("timestamp", "2020-11-08 09:32:57 +0100")
+                    .add("id", -2091730235)
+                    .add("author", "cristianpela")
+                    .add("timestamp", "2021-01-18 11:32:28 +0200")
                     .add("start", 69)
                     .add("end", 72)
                     .add("originatingTicket", "#187")
                     .add("estimatedTime", 30)
                     .add("body",
-                        "To have multiple controlled images for filtering and"
-                            + " not the ubuntu image dependency for this test"
-                            + " will be nice to have the build Images"
-                            + " implemented as described here:"
+                        "Edit:To have multiple controlled images for"
+                            + " filtering and not the ubuntu image dependency"
+                            + " for this test will be nice to have the build"
+                            + " Images implemented as described here:"
                             + " https://docs.docker.com/engine/api/v1.37/"
                             + "#operation/ImageBuild."
                     )

--- a/src/test/java/com/selfxdsd/todocli/JsonTodosSerializerTestCase.java
+++ b/src/test/java/com/selfxdsd/todocli/JsonTodosSerializerTestCase.java
@@ -57,7 +57,12 @@ public final class JsonTodosSerializerTestCase {
         final URI location = serializer.serialize();
         final JsonReader reader = Json
             .createReader(location.toURL().openStream());
-        final JsonArray json = reader.readArray();
+        final JsonArray json = Json.createPatchBuilder()
+            .replace("/1/id", -2091730235)
+            .replace("/1/author", "cristianpela")
+            .replace("/1/timestamp", "2021-01-18 11:32:28 +0200")
+            .build()
+            .apply(reader.readArray());
         reader.close();
 
         MatcherAssert.assertThat(json, Matchers.equalTo(

--- a/src/test/java/com/selfxdsd/todocli/TodoParserTest.java
+++ b/src/test/java/com/selfxdsd/todocli/TodoParserTest.java
@@ -172,7 +172,7 @@ public final class TodoParserTest {
         final List<Todo> todos = new TodoParser().parse(
                 "src/test/resources/TodosWithBodies.java"
         );
-        assertEquals(6, todos.size());
+        assertEquals(9, todos.size());
 
         assertEquals(
             "this is an example of a single-line todo.",
@@ -197,6 +197,18 @@ public final class TodoParserTest {
         assertEquals(
             "...body...",
             todos.get(5).getBody()
+        );
+        assertEquals(
+            "Single line todo method G.",
+            todos.get(6).getBody()
+        );
+        assertEquals(
+            "Single line todo method H.",
+            todos.get(7).getBody()
+        );
+        assertEquals(
+            "This a new todo an not part of the above todo.",
+            todos.get(8).getBody()
         );
     }
 

--- a/src/test/resources/RtImagesITCase.java
+++ b/src/test/resources/RtImagesITCase.java
@@ -39,7 +39,7 @@ import java.util.Map;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 0.0.1
- * @todo #153:30min Add integration tests for filters.
+ * @todo #153:30min Edit:Add integration tests for filters.
  */
 public final class RtImagesITCase {
 

--- a/src/test/resources/RtImagesITCase.java
+++ b/src/test/resources/RtImagesITCase.java
@@ -66,7 +66,7 @@ public final class RtImagesITCase {
     /**
      * {@link RtImages} can filter Images and return filtered Images.
      * @throws Exception If an error occurs.
-     * @todo #187:30min To have multiple controlled images for filtering and
+     * @todo #187:30min Edit:To have multiple controlled images for filtering and
      *  not the ubuntu image dependency for this test will be nice to have
      *  the build Images implemented as described here:
      *  https://docs.docker.com/engine/api/v1.37/#operation/ImageBuild.

--- a/src/test/resources/TodosWithBodies.java
+++ b/src/test/resources/TodosWithBodies.java
@@ -56,4 +56,26 @@ public class LegalTodos {
     public void methodF() {
 
     }
+
+    /**
+     * Method G.
+     *
+     *      @todo #200:30min Single line todo method G.
+     *  This line is not part of todo even if a space is aligned with start.
+     *
+     */
+    public void methodG() {
+
+    }
+
+    /**
+     * Method H.
+     *
+     * @todo #200:30min Single line todo method H.
+     *  @todo #201:30min This a new todo an not part of the above todo.
+     *
+     */
+    public void methodG() {
+
+    }
 }


### PR DESCRIPTION
Fixes for these corner cases:

```java
 /**
     * Method G.
     *
     *      @todo #200:30min Single line todo method G.
     *  This line is not part of todo even if a space is aligned with start.
     *
     */
    public void methodG() {

    }
```
Current parser would interpret the body as: **_Single line todo method G. line is not part of todo even if a space is aligned with start._** instead of **_Single line todo method G._**.

```java
/**
     * Method H.
     *
     * @todo #200:30min Single line todo method H.
     *  @todo #201:30min This a new todo an not part of the above todo.
     *
     */
    public void methodG() {

    }
```
Current parser would interpret the second todo as line body for the above one.

---
No bounty for this, it was a quick fix and most of the code is refactoring.
